### PR TITLE
Add deployment script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+desc "Uploads files to the machine at sinclairtarget.com via rsync"
+task :deploy do
+  sh 'rsync -vz * static@sinclairtarget.com:/srv/www/paysymmetry.com --exclude "Rakefile"'
+end


### PR DESCRIPTION
Adding a `Rakefile` with a task that will copy the files in the folder up to our server at `sinclairtarget.com` (which also happens to be `paysymmetry.com`). This won't work for you, Liz, until I set you up with SSH access. Something to do this weekend.

When you do get set up this script allows you to deploy everything from the command line with:

```
$ rake deploy
```
